### PR TITLE
chore: add url to disqus config

### DIFF
--- a/app/notes/[slug]/page.tsx
+++ b/app/notes/[slug]/page.tsx
@@ -174,8 +174,10 @@ export default async function Page({ params }: Props) {
         </div>
 
         <hr className="border-t-1 border-gray-300/60" />
-
-        <DisqusComments slug={slug} url={""} title={""} />
+        <DisqusComments
+          slug={params.slug}
+          url={`${siteConfig.url}/notes/${params.slug}`}
+        />
       </div>
     </>
   )

--- a/components/comments.tsx
+++ b/components/comments.tsx
@@ -9,7 +9,6 @@ import { useInView } from "react-intersection-observer"
 interface ICommentPprops {
   url: string
   slug: string
-  title: string
 }
 
 export const Comments = () => {
@@ -26,7 +25,7 @@ export const Comments = () => {
   )
 }
 
-export const DisqusComments = ({ url, slug, title }: ICommentPprops) => {
+export const DisqusComments = ({ url, slug }: ICommentPprops) => {
   const { resolvedTheme = "light" } = useTheme()
   const { ref, inView } = useInView({
     threshold: 0,
@@ -35,9 +34,8 @@ export const DisqusComments = ({ url, slug, title }: ICommentPprops) => {
   })
   const disqusShortname = "yashhere"
   const disqusConfig = {
-    url: url,
     identifier: slug,
-    title: title,
+    url: url,
   }
 
   return (


### PR DESCRIPTION
Fixing Disqus identifier fiasco (especially for fossmeet-18). For this post, the identifier is not being created. So, I am using the link parameter to link to its thread. This probably won't work for any other domain including localhost.