### PR TITLE
feat: improve visual design and code block styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
             level="h2"
             className="text-foreground text-2xl font-semibold"
           >
-            Hey, I&apos;m Yash
+            Yash Agarwal
           </Heading>
           <p className="text-foreground/60 mt-1 text-base italic">
             Developer / Creator / Explorer

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,14 +16,12 @@ export default function Page() {
           >
             Yash Agarwal
           </Heading>
-          <p className="text-foreground/60 mt-1 text-base italic">
-            Developer / Creator / Explorer
-          </p>
+          <p className="mt-1 text-base italic">Engineer / Builder / Learner </p>
         </div>
 
         <div className="text-foreground/90 space-y-6 text-base leading-relaxed">
           <p>
-            This is my home on the web. I write code at{" "}
+            Welcome to my corner of the internet. I write code at{" "}
             <Link
               href="https://netskope.com"
               target="_blank"
@@ -36,8 +34,9 @@ export default function Page() {
             protect businesses&apos; data at rest.
           </p>
           <p>
-            Outside of software I like to tinker with homelab setups, explore
-            cybersecurity, and document my experiments. You can find me on{" "}
+            Outside of work, I enjoy tinkering with my homelab, diving into
+            cybersecurity and LLMs, and documenting my experiments. You can
+            connect with me on{" "}
             <Link
               href="https://x.com/yash__here"
               target="_blank"

--- a/components/content/featured-notes.tsx
+++ b/components/content/featured-notes.tsx
@@ -29,14 +29,14 @@ export async function FeaturedNotes({ count }: { count: number }) {
   // Sort them by update date
   notesFiltered.sort((a, b) => b.note.updatedOn - a.note.updatedOn)
   return (
-    <div className="flex flex-col justify-start gap-2 md:gap-8">
+    <div className="flex flex-col justify-start gap-5">
       <div className="w-full">
         <NoteList homePage={true} notes={notesFiltered.slice(0, count)} />
       </div>
       <Link
         href="/notes"
-        className="group text-foreground/80 hover:text-primary mt-2 inline-flex items-center gap-1 text-base font-medium transition-colors"
-        variant="nav"
+        className="group text-foreground/80 hover:text-primary text-md mt-3 inline-flex items-center gap-1 font-medium transition-colors"
+        variant="text"
       >
         <span>View all notes</span>
         <ArrowRightIcon className="relative top-[1px] h-4 w-4 transition-transform duration-200 ease-out group-hover:translate-x-1" />

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,30 +1,28 @@
-import { FC, Suspense } from "react"
-
-import { LastVisitor } from "../interactive/last-visitor"
+import { FC } from "react"
 
 export const Footer: FC = () => {
   const currentYear = new Date().getFullYear()
 
   return (
-    <footer className="border-border bg-background mt-auto w-full border-t-1">
-      <div className="mx-auto max-w-xl px-4 py-8 md:px-0">
-        <div className="text-foreground/70 space-y-4 text-center text-sm">
+    <footer className="border-border bg-background mt-auto w-full border-t-2">
+      <div className="mx-auto max-w-xl py-2">
+        <div className="text-foreground/70 space-y-1 text-center text-sm">
           <div>
             © {currentYear === 2016 ? currentYear : `2016 - ${currentYear}`}{" "}
-            Yash Agarwal. All rights reserved.
+            Yash Agarwal.
           </div>
 
-          <Suspense
+          {/* <Suspense
             fallback={
-              <div className="mb-6 flex justify-center">
+              <div className="flex justify-center">
                 <div className="bg-muted h-5 w-32 animate-pulse rounded" />
               </div>
             }
           >
-            <div className="mb-6 flex justify-center">
+            <div className="flex justify-center">
               <LastVisitor />
             </div>
-          </Suspense>
+          </Suspense> */}
         </div>
       </div>
     </footer>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -34,7 +34,7 @@
 @layer base {
   :root {
     /* Using Tailwind color names directly */
-    --background: theme("colors.white");
+    --background: theme("colors.slate.50");
     --foreground: theme("colors.slate.950");
 
     --card: theme("colors.white");
@@ -83,10 +83,10 @@
 
   .dark {
     /* Dark mode theme colors */
-    --background: theme("colors.slate.950");
+    --background: theme("colors.slate.900");
     --foreground: theme("colors.slate.50");
 
-    --card: theme("colors.slate.900");
+    --card: theme("colors.slate.800");
     --card-foreground: theme("colors.slate.50");
 
     --popover: theme("colors.slate.900");
@@ -112,7 +112,7 @@
     --ring: theme("colors.slate.300");
 
     /* Code syntax highlighting */
-    --syntax-bg: theme("colors.slate.950");
+    --syntax-bg: theme("colors.slate.800");
     --syntax-highlight: theme("colors.slate.800");
     --syntax-txt: theme("colors.slate.50");
     --syntax-comment: theme("colors.slate.400");
@@ -152,14 +152,14 @@
   /* Fix for https://github.com/disqus/disqus-react/issues/153 */
   :root,
   .comments {
-    background-color: #ffffff !important; /* white */
+    background-color: #f8fafc !important; /* slate-50 */
     color: #0f172a !important; /* slate-950 */
   }
 
   /* Dark mode comments - using hex values */
   :root,
   .dark .comments {
-    background-color: #020617 !important; /* slate-950 */
+    background-color: #0f172a !important; /* slate-900 */
     color: #f8fafc !important; /* slate-50 */
   }
 

--- a/styles/mdx.css
+++ b/styles/mdx.css
@@ -96,7 +96,6 @@ span[data-rehype-pretty-code-figure] code {
   word-break: break-word;
   overflow-wrap: break-word;
   border: none;
-  line-height: 1.7;
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;
 }
@@ -158,33 +157,29 @@ figure[data-rehype-pretty-code-figure] pre {
 }
 
 figure[data-rehype-pretty-code-figure] code {
-  @apply grid w-full text-sm;
+  @apply grid w-full py-2;
   counter-reset: line;
   box-decoration-break: clone;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
   font-family: var(--font-mono);
-  font-size: 0.9rem;
-  line-height: 1.6;
+  font-size: 0.85rem;
 }
 
 figure[data-rehype-pretty-code-figure] code [data-line] {
-  @apply border-l-2 border-l-transparent px-5;
-  padding: 0.15rem 1.25rem;
+  @apply border-l-2 border-l-transparent px-2;
 }
 
 /* Responsive adjustments for smaller screens */
 @media (max-width: 640px) {
   figure[data-rehype-pretty-code-figure] pre {
-    font-size: 0.875rem;
+    font-size: 0.825rem;
   }
 
   figure[data-rehype-pretty-code-figure] code {
-    font-size: 0.875rem;
+    font-size: 0.825rem;
   }
 
   figure[data-rehype-pretty-code-figure] code [data-line] {
-    @apply px-4;
+    @apply px-2;
   }
 
   /* Smaller line numbers on mobile */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -103,7 +103,7 @@ const typographyStyles = {
         borderRadius: "0.375rem",
         overflowX: "auto",
         fontSize: "0.9375rem",
-        padding: "1rem",
+        padding: "0.75rem",
       },
       code: {
         color: "var(--syntax-string)",
@@ -128,13 +128,13 @@ const typographyStyles = {
         // Line numbers and highlighting
         pre: {
           fontSize: "0.9375rem",
-          padding: "1rem 0",
+          padding: "0.75rem 0",
         },
         "[data-line]": {
           borderLeftWidth: "2px",
           borderColor: "transparent",
-          paddingLeft: "1.25rem",
-          paddingRight: "1.25rem",
+          paddingLeft: "0.75rem",
+          paddingRight: "0.75rem",
         },
         "[data-highlighted-line]": {
           backgroundColor: "var(--syntax-highlight)",


### PR DESCRIPTION
- Replace pure white/black backgrounds with softer slate-50/slate-900 shades 
- Reduce code block padding from 1rem to 0.75rem for more compact appearance 
- Update syntax highlighting background to slate-800 in dark mode 
- Adjust homepage layout with tighter spacing and refined typography 
- Simplify footer layout and remove temporarily disabled last visitor component 
- Update Disqus comments background colors to match new theme scheme