### PR TITLE
feat: add scratch notes section for quick AI-assisted notes

### DIFF
--- a/scripts/create-scratch-note.ts
+++ b/scripts/create-scratch-note.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bun
+
+/**
+ * Create a new scratch note with minimal friction.
+ *
+ * Usage:
+ *   bun scripts/create-scratch-note.ts                    # interactive
+ *   bun scripts/create-scratch-note.ts "Title" "Body..."  # non-interactive (for LLM agents)
+ */
+
+import fs from "node:fs/promises"
+import path from "node:path"
+
+const CONTENT_DIR = "src/content/scratch_notes"
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+}
+
+function todayStr(): string {
+  return new Date().toISOString().split("T")[0]
+}
+
+function dateTimeStr(): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Kolkata",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  })
+    .format(new Date())
+    .replace(", ", "T") + "+05:30"
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+
+  let title: string
+  let body: string
+
+  if (args.length >= 2) {
+    // Non-interactive mode (for LLM agents)
+    title = args[0]
+    body = args.slice(1).join(" ")
+  } else {
+    // Interactive mode
+    const rl = (await import("node:readline")).createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    })
+
+    title = await new Promise<string>((resolve) => {
+      rl.question("Title: ", resolve)
+    })
+
+    console.log("Body (type . on a new line to finish):")
+    const lines: string[] = []
+    for await (const line of rl) {
+      if (line === ".") break
+      lines.push(line)
+    }
+    body = lines.join("\n")
+    rl.close()
+  }
+
+  if (!title.trim()) {
+    console.error("Title is required.")
+    process.exit(1)
+  }
+
+  const slug = slugify(title)
+  const date = todayStr()
+  const dirName = `${date}-${slug}`
+
+  let finalDirName = dirName
+  let counter = 1
+  while (await fs.stat(path.join(CONTENT_DIR, finalDirName)).catch(() => null)) {
+    finalDirName = `${dirName}-${counter}`
+    counter++
+  }
+
+  const dirPath = path.join(CONTENT_DIR, finalDirName)
+  await fs.mkdir(dirPath, { recursive: true })
+
+  const frontmatter = `---
+title: ${JSON.stringify(title)}
+createdOn: ${JSON.stringify(dateTimeStr())}
+status: published
+---
+
+${body}
+`
+
+  const filePath = path.join(dirPath, "index.mdx")
+  await fs.writeFile(filePath, frontmatter, "utf-8")
+
+  console.log(`Created: ${filePath}`)
+}
+
+main().catch((err) => {
+  console.error("Error:", err)
+  process.exit(1)
+})

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -16,6 +16,7 @@ const isActive = (href: string) => {
 const footerLinks = [
   { name: "Home", href: "/" },
   { name: "Notes", href: "/notes" },
+  { name: "Scratch", href: "/scratch" },
   { name: "Work", href: "/work" },
   { name: "Now", href: "/now" },
   { name: "About", href: "/about" },
@@ -24,8 +25,8 @@ const footerLinks = [
   { name: "Newsletter", href: "/newsletter" },
 ]
 
-const row1 = footerLinks.slice(0, 4)
-const row2 = footerLinks.slice(4)
+const row1 = footerLinks.slice(0, 5)
+const row2 = footerLinks.slice(5)
 ---
 
 <footer class="border-border bg-background mt-auto w-full border-t">

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -22,6 +22,16 @@ const notes = defineCollection({
   }),
 })
 
+const rawNotes = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    createdOn: z.coerce.date(),
+    status: z.enum(["draft", "published"]).default("draft"),
+  }),
+})
+
 export const collections = {
   notes,
+  scratch_notes: rawNotes,
 }

--- a/src/lib/scratch-content.ts
+++ b/src/lib/scratch-content.ts
@@ -1,0 +1,24 @@
+import { getCollection, type CollectionEntry } from "astro:content"
+import { compareDesc } from "date-fns"
+
+export type RawNoteEntry = CollectionEntry<"scratch_notes">
+
+export async function getRawNotes(): Promise<RawNoteEntry[]> {
+  const notes = await getCollection("scratch_notes")
+  return notes.sort((a, b) => compareDesc(a.data.createdOn, b.data.createdOn))
+}
+
+export async function getPublishedRawNotes(): Promise<RawNoteEntry[]> {
+  const notes = await getRawNotes()
+  if (import.meta.env.DEV) {
+    return notes
+  }
+  return notes.filter((n) => n.data.status === "published")
+}
+
+export async function getRawNoteBySlug(
+  slug: string,
+): Promise<RawNoteEntry | undefined> {
+  const notes = await getCollection("scratch_notes")
+  return notes.find((n) => n.slug === slug)
+}

--- a/src/pages/scratch/[slug].astro
+++ b/src/pages/scratch/[slug].astro
@@ -1,0 +1,44 @@
+---
+import { getCollection } from "astro:content"
+import BaseLayout from "../../layouts/BaseLayout.astro"
+import Heading from "../../components/ui/Heading.astro"
+
+export async function getStaticPaths() {
+  const notes = await getCollection("scratch_notes")
+  return notes.map((note) => ({
+    params: { slug: note.slug },
+    props: { note },
+  }))
+}
+
+const { note } = Astro.props
+const { Content } = await note.render()
+
+function formatDate(d: Date): string {
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })
+}
+---
+
+<BaseLayout
+  title={note.data.title}
+  description="A scratch note."
+>
+  <div class="mt-6">
+    <a href="/scratch" class="text-muted-foreground hover:text-foreground text-sm no-underline transition-colors">
+      &larr; Scratch
+    </a>
+  </div>
+
+  <Heading level="h2" as="h1" class="mt-4 mb-2">{note.data.title}</Heading>
+  <p class="text-muted-foreground text-sm mb-8">{formatDate(note.data.createdOn)}</p>
+
+  <article class="prose dark:prose-invert max-w-none">
+    <Content />
+  </article>
+
+  <div class="mt-12 pt-6 border-t border-border">
+    <a href="/scratch" class="text-muted-foreground hover:text-foreground text-sm no-underline transition-colors">
+      &larr; All scratch notes
+    </a>
+  </div>
+</BaseLayout>

--- a/src/pages/scratch/index.astro
+++ b/src/pages/scratch/index.astro
@@ -1,0 +1,135 @@
+---
+import { Icon } from "astro-icon/components"
+import Heading from "../../components/ui/Heading.astro"
+import BaseLayout from "../../layouts/BaseLayout.astro"
+import { getPublishedRawNotes } from "../../lib/scratch-content"
+
+const notes = await getPublishedRawNotes()
+
+function formatDate(d: Date): string {
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })
+}
+---
+
+<BaseLayout
+  title="Scratch"
+  description="Quick notes, often AI-assisted. Work in progress."
+>
+  <Heading level="h2" as="h1" class="mt-6 mb-2">
+    Scratch
+    <span class="text-muted-foreground text-base font-normal ml-2" data-count>{notes.length}</span>
+  </Heading>
+
+  <p class="text-muted-foreground mb-4">
+    Quick notes about things I figured out. Often written with AI assistance.
+    These are not polished posts. Treat them as work in progress.
+  </p>
+
+  <div class="pb-3">
+    <div class="relative">
+      <Icon name="lucide:search" class="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground pointer-events-none" />
+      <input
+        type="text"
+        id="search-input"
+        placeholder="Search scratch notes..."
+        class="h-8 w-full rounded border border-foreground/15 bg-background pl-8 pr-3 text-sm outline-none focus:border-foreground/30 transition-colors"
+      />
+    </div>
+  </div>
+
+  {
+    notes.length === 0 && (
+      <p class="text-muted-foreground">No scratch notes yet.</p>
+    )
+  }
+
+  <ul id="notes-list" class="space-y-4">
+    {notes.map((note, i) => (
+      <li class="flex items-baseline gap-3 py-1 px-0.5">
+        <span class="text-muted-foreground shrink-0 tabular-nums text-xs w-5 text-right">
+          {notes.length - i}
+        </span>
+        <a
+          href={`/scratch/${note.slug}`}
+          class="text-foreground min-w-0 flex-1 no-underline hover:underline"
+          data-note-title
+        >
+          {note.data.title}
+        </a>
+        <span class="text-muted-foreground shrink-0 text-xs">
+          {formatDate(note.data.createdOn)}
+        </span>
+      </li>
+    ))}
+  </ul>
+
+  <div id="no-results" class="hidden py-8 text-center text-muted-foreground">
+    No scratch notes found matching your search.
+  </div>
+</BaseLayout>
+
+<script is:inline>
+  window.addEventListener('DOMContentLoaded', async () => {
+    const searchInput = document.getElementById("search-input")
+    const notesList = document.getElementById("notes-list")
+    const noResults = document.getElementById("no-results")
+
+    if (!searchInput || !notesList) return
+
+    let pagefind
+    try {
+      pagefind = await import("/pagefind/pagefind.js")
+      await pagefind.init()
+    } catch (error) {
+      console.error('Failed to load Pagefind:', error)
+      return
+    }
+
+    const listItems = notesList.querySelectorAll("li")
+
+    searchInput.addEventListener("input", async (e) => {
+      const term = e.target.value.trim()
+
+      if (term === "") {
+        listItems.forEach((li) => { li.style.display = "" })
+        if (noResults) noResults.classList.add("hidden")
+
+        const countElement = document.querySelector('[data-count]')
+        if (countElement) countElement.textContent = listItems.length.toString()
+        return
+      }
+
+      try {
+        const search = await pagefind.search(term)
+        const results = await Promise.all(search.results.map(r => r.data()))
+
+        const resultUrls = new Set(
+          results.map((result) => {
+            return result.url.replace(/\/index\.html$/, '').replace(/\/$/, '')
+          })
+        )
+
+        let visibleCount = 0
+        listItems.forEach((li) => {
+          const link = li.querySelector("a")
+          const url = link?.getAttribute("href") || ""
+          const normalizedUrl = url.replace(/\/index\.html$/, '').replace(/\/$/, '')
+
+          if (resultUrls.has(normalizedUrl)) {
+            li.style.display = ""
+            visibleCount++
+          } else {
+            li.style.display = "none"
+          }
+        })
+
+        if (noResults) noResults.classList.toggle("hidden", visibleCount > 0)
+
+        const countElement = document.querySelector('[data-count]')
+        if (countElement) countElement.textContent = visibleCount.toString()
+      } catch (error) {
+        console.error('Pagefind search error:', error)
+      }
+    })
+  })
+</script>


### PR DESCRIPTION
## Summary

Adds a `/scratch` section for quick notes about things figured out, often with AI assistance. These are intentionally separate from polished `/notes` posts — lower bar for publishing, honest about AI involvement.

## What changed

- **New content collection** `scratch_notes` — minimal schema (title, createdOn, status). No tags, categories, or series.
- **Script** `scripts/create-scratch-note.ts` — interactive mode or non-interactive (`bun scripts/create-scratch-note.ts "Title" "Body"`) for LLM agent use.
- **`/scratch` listing page** — chronological list with Pagefind search, dynamic count, and "no results" message.
- **`/scratch/[slug]` individual page** — minimal layout, prose-styled body, no BlogLayout chrome.
- **Footer** includes Scratch link. Top nav does not.
- **RSS and homepage** exclude scratch notes by design.

> ![HARNESS](https://img.shields.io/badge/Claude_Sonnet_4_(200K)-D97757?logo=claude&logoColor=white)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Claude_Sonnet_4_(200K)-D97757?logo=claude&logoColor=white)