### PR TITLE
Add cmd+k search modal with Pagefind

### DIFF
--- a/src/components/interactive/SearchModal.astro
+++ b/src/components/interactive/SearchModal.astro
@@ -102,7 +102,7 @@
             @click="select(result.url)"
             @mouseenter="selectedIndex = index"
             class="w-full px-4 py-2 text-left text-sm hover:bg-muted/50 transition-colors"
-            :class="{ 'bg-muted/30': index === selectedIndex }"
+            :class="{ 'bg-muted': index === selectedIndex }"
           >
             <div class="text-foreground truncate" x-text="result.meta?.title || result.url"></div>
             <div class="text-muted-foreground text-xs truncate mt-0.5" x-html="result.excerpt"></div>

--- a/src/components/interactive/SearchModal.astro
+++ b/src/components/interactive/SearchModal.astro
@@ -91,7 +91,7 @@
           x-model="query"
           @input.debounce.150ms="search()"
           placeholder="Search notes..."
-          class="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          class="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground focus:ring-0"
         >
         <kbd class="hidden sm:inline-flex items-center rounded border border-border bg-muted/50 px-1.5 py-0.5 text-xs text-muted-foreground font-mono">esc</kbd>
       </div>

--- a/src/components/interactive/SearchModal.astro
+++ b/src/components/interactive/SearchModal.astro
@@ -56,7 +56,8 @@
     },
 
     onKeydown(e) {
-      if (e.key === 'Escape') { this.open = false }
+      if (!this.open) return
+      if (e.key === 'Escape') { this.open = false; return }
       if (e.key === 'ArrowDown') { e.preventDefault(); this.selectedIndex = Math.min(this.selectedIndex + 1, this.results.length - 1) }
       if (e.key === 'ArrowUp') { e.preventDefault(); this.selectedIndex = Math.max(this.selectedIndex - 1, 0) }
       if (e.key === 'Enter' && this.results[this.selectedIndex]) { this.select(this.results[this.selectedIndex].url) }
@@ -65,6 +66,7 @@
   @keydown.window.cmd.k.prevent="open = true"
   @keydown.window.ctrl.k.prevent="open = true"
   @open-search.window="open = true"
+  @keydown.window="onKeydown($event)"
 >
   <div
     x-show="open"
@@ -81,7 +83,7 @@
     @click.outside="open = false"
     x-cloak
   >
-    <div class="rounded-lg border border-border bg-background shadow-2xl" @keydown="onKeydown">
+    <div class="rounded-lg border border-border bg-background shadow-2xl">
       <div class="flex items-center gap-2 border-b border-border px-4 py-3">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-muted-foreground shrink-0"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
         <input

--- a/src/components/interactive/SearchModal.astro
+++ b/src/components/interactive/SearchModal.astro
@@ -5,6 +5,7 @@
     results: [],
     loading: false,
     selectedIndex: 0,
+    pagefind: null,
 
     init() {
       this.$watch('open', (v) => {
@@ -25,9 +26,11 @@
       if (!this.query.trim()) { this.results = []; return }
       this.loading = true
       try {
-        const pf = await import('/pagefind/pagefind.js')
-        await pf.init()
-        const s = await pf.search(this.query)
+        if (!this.pagefind) {
+          this.pagefind = await import('/pagefind/pagefind.js')
+          await this.pagefind.init()
+        }
+        const s = await this.pagefind.search(this.query)
         const items = await Promise.all(s.results.map(r => r.data()))
         this.results = items.filter(item =>
           item.url.startsWith('/notes/') || item.url.startsWith('/scratch/')
@@ -51,6 +54,7 @@
   }"
   @keydown.window.cmd.k.prevent="open = true"
   @keydown.window.ctrl.k.prevent="open = true"
+  @open-search.window="open = true"
 >
   <div
     x-show="open"
@@ -63,7 +67,7 @@
   <div
     x-show="open"
     x-transition
-    class="fixed inset-x-0 top-[20vh] z-50 mx-auto max-w-lg px-4"
+    class="fixed inset-x-0 top-[15vh] z-50 mx-auto max-w-xl px-4"
     @click.outside="open = false"
     x-cloak
   >

--- a/src/components/interactive/SearchModal.astro
+++ b/src/components/interactive/SearchModal.astro
@@ -5,9 +5,10 @@
     results: [],
     loading: false,
     selectedIndex: 0,
-    pagefind: null,
+    pagefindReady: false,
 
     init() {
+      this.preloadPagefind()
       this.$watch('open', (v) => {
         if (v) {
           this.$nextTick(() => {
@@ -22,20 +23,29 @@
       })
     },
 
+    async preloadPagefind() {
+      try {
+        const pf = await import('/pagefind/pagefind.js')
+        await pf.init()
+        this.pagefindReady = true
+        window.__pagefind = pf
+      } catch {
+        this.pagefindReady = false
+      }
+    },
+
     async search() {
-      if (!this.query.trim()) { this.results = []; return }
+      if (!this.query.trim() || !this.pagefindReady) { this.results = []; return }
       this.loading = true
       try {
-        if (!this.pagefind) {
-          this.pagefind = await import('/pagefind/pagefind.js')
-          await this.pagefind.init()
-        }
-        const s = await this.pagefind.search(this.query)
+        const s = await window.__pagefind.search(this.query)
         const items = await Promise.all(s.results.map(r => r.data()))
         this.results = items.filter(item =>
           item.url.startsWith('/notes/') || item.url.startsWith('/scratch/')
         ).slice(0, 8)
         this.selectedIndex = 0
+      } catch {
+        this.results = []
       } finally {
         this.loading = false
       }
@@ -98,8 +108,12 @@
         </template>
       </div>
 
-      <div x-show="query && !loading && results.length === 0" class="px-4 py-6 text-center text-muted-foreground text-sm">
+      <div x-show="query && !loading && results.length === 0 && pagefindReady" class="px-4 py-6 text-center text-muted-foreground text-sm">
         No results found.
+      </div>
+
+      <div x-show="query && !loading && !pagefindReady" class="px-4 py-6 text-center text-muted-foreground text-sm">
+        Search is not available right now.
       </div>
 
       <div class="hidden sm:flex items-center gap-4 border-t border-border px-4 py-2 text-xs text-muted-foreground">

--- a/src/components/interactive/SearchModal.astro
+++ b/src/components/interactive/SearchModal.astro
@@ -91,7 +91,7 @@
           x-model="query"
           @input.debounce.150ms="search()"
           placeholder="Search notes..."
-          class="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground focus:ring-0"
+          class="flex-1 bg-transparent text-sm outline-none focus:outline-none focus:ring-0 placeholder:text-muted-foreground" style="-webkit-tap-highlight-color: transparent;"
         >
         <kbd class="hidden sm:inline-flex items-center rounded border border-border bg-muted/50 px-1.5 py-0.5 text-xs text-muted-foreground font-mono">esc</kbd>
       </div>

--- a/src/components/interactive/SearchModal.astro
+++ b/src/components/interactive/SearchModal.astro
@@ -1,0 +1,108 @@
+<div
+  x-data="{
+    open: false,
+    query: '',
+    results: [],
+    loading: false,
+    selectedIndex: 0,
+
+    init() {
+      this.$watch('open', (v) => {
+        if (v) {
+          this.$nextTick(() => {
+            const input = this.$el.querySelector('input[type=text]')
+            if (input) input.focus()
+          })
+        } else {
+          this.query = ''
+          this.results = []
+          this.selectedIndex = 0
+        }
+      })
+    },
+
+    async search() {
+      if (!this.query.trim()) { this.results = []; return }
+      this.loading = true
+      try {
+        const pf = await import('/pagefind/pagefind.js')
+        await pf.init()
+        const s = await pf.search(this.query)
+        const items = await Promise.all(s.results.map(r => r.data()))
+        this.results = items.filter(item =>
+          item.url.startsWith('/notes/') || item.url.startsWith('/scratch/')
+        ).slice(0, 8)
+        this.selectedIndex = 0
+      } finally {
+        this.loading = false
+      }
+    },
+
+    select(url) {
+      window.location.href = url
+    },
+
+    onKeydown(e) {
+      if (e.key === 'Escape') { this.open = false }
+      if (e.key === 'ArrowDown') { e.preventDefault(); this.selectedIndex = Math.min(this.selectedIndex + 1, this.results.length - 1) }
+      if (e.key === 'ArrowUp') { e.preventDefault(); this.selectedIndex = Math.max(this.selectedIndex - 1, 0) }
+      if (e.key === 'Enter' && this.results[this.selectedIndex]) { this.select(this.results[this.selectedIndex].url) }
+    }
+  }"
+  @keydown.window.cmd.k.prevent="open = true"
+  @keydown.window.ctrl.k.prevent="open = true"
+>
+  <div
+    x-show="open"
+    x-transition.opacity.duration.200ms
+    class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+    @click="open = false"
+    x-cloak
+  ></div>
+
+  <div
+    x-show="open"
+    x-transition
+    class="fixed inset-x-0 top-[20vh] z-50 mx-auto max-w-lg px-4"
+    @click.outside="open = false"
+    x-cloak
+  >
+    <div class="rounded-lg border border-border bg-background shadow-2xl" @keydown="onKeydown">
+      <div class="flex items-center gap-2 border-b border-border px-4 py-3">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-muted-foreground shrink-0"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        <input
+          type="text"
+          x-model="query"
+          @input.debounce.150ms="search()"
+          placeholder="Search notes..."
+          class="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        >
+        <kbd class="hidden sm:inline-flex items-center rounded border border-border bg-muted/50 px-1.5 py-0.5 text-xs text-muted-foreground font-mono">esc</kbd>
+      </div>
+
+      <div x-show="results.length > 0" class="max-h-64 overflow-y-auto py-2">
+        <template x-for="(result, index) in results" :key="result.url">
+          <button
+            @click="select(result.url)"
+            @mouseenter="selectedIndex = index"
+            class="w-full px-4 py-2 text-left text-sm hover:bg-muted/50 transition-colors"
+            :class="{ 'bg-muted/30': index === selectedIndex }"
+          >
+            <div class="text-foreground truncate" x-text="result.meta?.title || result.url"></div>
+            <div class="text-muted-foreground text-xs truncate mt-0.5" x-html="result.excerpt"></div>
+          </button>
+        </template>
+      </div>
+
+      <div x-show="query && !loading && results.length === 0" class="px-4 py-6 text-center text-muted-foreground text-sm">
+        No results found.
+      </div>
+
+      <div class="hidden sm:flex items-center gap-4 border-t border-border px-4 py-2 text-xs text-muted-foreground">
+        <span class="flex items-center gap-1"><kbd class="rounded border border-border bg-muted/50 px-1 font-mono text-xs">&uarr;&darr;</kbd> navigate</span>
+        <span class="flex items-center gap-1"><kbd class="rounded border border-border bg-muted/50 px-1 font-mono text-xs">&crarr;</kbd> open</span>
+        <span class="flex items-center gap-1"><kbd class="rounded border border-border bg-muted/50 px-1 font-mono text-xs">esc</kbd> close</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/components/interactive/SearchModal.astro
+++ b/src/components/interactive/SearchModal.astro
@@ -84,7 +84,7 @@
     x-cloak
   >
     <div class="rounded-lg border border-border bg-background shadow-2xl">
-      <div class="flex items-center gap-2 border-b border-border px-4 py-3">
+      <div class="flex items-center gap-2 px-4 py-3">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-muted-foreground shrink-0"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
         <input
           type="text"

--- a/src/components/layout/Navigation.astro
+++ b/src/components/layout/Navigation.astro
@@ -3,7 +3,6 @@ import ThemeToggle from "../interactive/ThemeToggle.astro"
 
 const navItems = [
   { name: "Notes", href: "/notes" },
-  { name: "Now", href: "/now" },
   { name: "Work", href: "/work" },
 ]
 

--- a/src/components/layout/Navigation.astro
+++ b/src/components/layout/Navigation.astro
@@ -45,6 +45,13 @@ const isActive = (href: string) => {
             {item.name}
           </a>
         ))}
+        <button
+          onclick="window.dispatchEvent(new CustomEvent('open-search'))"
+          class="text-muted-foreground hover:text-foreground transition-colors p-1"
+          aria-label="Search (cmd+k)"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        </button>
         <ThemeToggle />
       </div>
     </nav>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import "../styles/tooltip.css"
 
 import Footer from "../components/layout/Footer.astro"
 import Navigation from "../components/layout/Navigation.astro"
+import SearchModal from "../components/interactive/SearchModal.astro"
 import { siteConfig } from "../config/site"
 import { cn } from "../lib/utils"
 
@@ -112,5 +113,6 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site || "https://yashagar
       <slot />
     </main>
     <Footer />
+    <SearchModal />
   </body>
 </html>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -155,14 +155,13 @@ const breadcrumbItems = [
 
     <div class="mt-8 pt-6 pb-12 border-t border-border">
       <p class="text-muted-foreground">
-        Thoughts or feedback?{" "}
         <a
           href={`mailto:hello@yashagarwal.in?subject=${encodeURIComponent(`Re: ${title}`)}`}
           class="text-foreground underline underline-offset-2 hover:text-primary transition-colors"
         >
-          Reply via email
+          Send me an email
         </a>
-        . I read every message.
+        if you have thoughts or feedback. I read every message.
       </p>
     </div>
   </div>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -11,7 +11,6 @@ import Series from '../components/content/Series.astro';
 import RelatedNotes from '../components/content/RelatedNotes.astro';
 import Backlinks from '../components/content/Backlinks.astro';
 import ReadingProgress from '../components/content/ReadingProgress.astro';
-import { Icon } from 'astro-icon/components';
 import type { ImageMetadata } from 'astro';
 
 interface Props {
@@ -147,17 +146,7 @@ const breadcrumbItems = [
       </div>
     )}
 
-    <div class="mt-8 flex items-center justify-between">
-      <div class="flex items-center gap-3">
-        <a
-          href={`https://x.com/intent/tweet?text=${encodeURIComponent(`https://yashagarwal.in/notes/${slug}`)}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="text-muted-foreground hover:text-foreground text-sm no-underline border border-border rounded px-2 py-0.5 inline-flex items-center gap-1"
-        >
-          Share on X <Icon name="lucide:arrow-up-right" class="inline h-3 w-3" />
-        </a>
-      </div>
+    <div class="mt-8">
       <a href="/notes" class="text-muted-foreground hover:text-foreground text-sm transition-colors no-underline xl:hidden">
         &larr; Notes
       </a>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -146,12 +146,6 @@ const breadcrumbItems = [
       </div>
     )}
 
-    <div class="mt-8">
-      <a href="/notes" class="text-muted-foreground hover:text-foreground text-sm transition-colors no-underline xl:hidden">
-        &larr; Notes
-      </a>
-    </div>
-
     <div class="mt-8 pt-6 border-t border-border">
       <p class="text-muted-foreground">
         I send occasional updates about things I am building.


### PR DESCRIPTION
Global search modal that opens with `cmd+k` (or `ctrl+k`).

**What it does**:
- Opens a search modal overlay on any page
- Searches content pages only (`/notes/` and `/scratch/`)
- Keyboard navigation: `↑↓` to move, `↵` to open, `esc` to close
- Click outside to dismiss
- Shows title and excerpt for each result

**Also removes**: Share on X button from blog posts.

**Tech**: Uses the existing Pagefind integration (already indexes all content pages via `[data-pagefind-body]`). The modal lives in `BaseLayout` so it works on every page.