### PR TITLE
fix: remove negative margin from turnstile widget

### DIFF
--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -54,7 +54,7 @@ const isProduction = !!turnstileSiteKey
             <input type="text" name="website" tabindex="-1" autocomplete="off" class="absolute opacity-0 pointer-events-none" aria-hidden="true" />
             <input type="hidden" name="l" value="1706bf84-4ff4-4419-8aea-fcadb21a9d3b" />
             <div
-              class="cf-turnstile -mx-3"
+              class="cf-turnstile"
               data-sitekey={turnstileSiteKey}
               data-theme="auto"
               data-callback="onTurnstileVerified"


### PR DESCRIPTION
The `-mx-3` negative margin pulled the Turnstile widget beyond the form container edges on both sides, misaligning it with the text inputs that use `px-3` padding. Removes the class so the widget sits flush with the container and aligns with the inputs.