### PR TITLE
docs: add July 10 closed testing update to mums-memories page

### DIFF
--- a/src/pages/mums-memories.astro
+++ b/src/pages/mums-memories.astro
@@ -37,6 +37,52 @@ import BaseLayout from "../layouts/BaseLayout.astro"
       <div class="space-y-8">
         <div>
           <time
+            datetime="2026-07-10"
+            class="text-sm font-medium text-heading tracking-wide uppercase mb-3 block"
+          >
+            July 10, 2026
+          </time>
+          <ul class="space-y-4">
+            <li class="flex items-start gap-3">
+              <span
+                class="mt-2.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+              ></span>
+              <span>
+                Submitted the app for closed testing on Google Play Store.
+                The Play Console listing is live and testers can join via a Google Group.
+              </span>
+            </li>
+            <li class="flex items-start gap-3">
+              <span
+                class="mt-2.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+              ></span>
+              <span>
+                Upgraded to Expo SDK 57 and bumped version codes through a few rounds
+                while ironing out the build pipeline.
+              </span>
+            </li>
+            <li class="flex items-start gap-3">
+              <span
+                class="mt-2.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+              ></span>
+              <span>
+                Made the paywall live.
+              </span>
+            </li>
+            <li class="flex items-start gap-3">
+              <span
+                class="mt-2.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+              ></span>
+              <span>
+                Ran a craft pass using Claude Opus across the whole app: spring animations, interruptible transitions, shared headers, and a restructured Profile and Settings
+                screen.
+              </span>
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <time
             datetime="2026-07-08"
             class="text-sm font-medium text-heading tracking-wide uppercase mb-3 block"
           >


### PR DESCRIPTION
Adds a new update section for July 10, 2026 covering:

- Closed testing launch on Google Play (RC build 11)
- Expo SDK 57 upgrade
- Paywall live with contextual gates and server-side receipt verification
- Design craft pass (animations, shared headers, Profile/Settings restructure)
- Bug fixes (onboarding dead-end, compose-close dead-end, Sentry blind spots)

Sections are reverse chronological.